### PR TITLE
[add] color asset 추가 #SEO-3

### DIFF
--- a/Seoullo/Seoullo.xcodeproj/project.pbxproj
+++ b/Seoullo/Seoullo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E1BA3FAE2C909F4F00ED0ADA /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E1BA3FAD2C909F4F00ED0ADA /* Secrets.xcconfig */; };
+		E1BA3FB12C90A1A600ED0ADA /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E1BA3FB02C90A1A600ED0ADA /* Colors.xcassets */; };
 		E28B13582C8C3B14005F6236 /* SeoulloApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28B13572C8C3B14005F6236 /* SeoulloApp.swift */; };
 		E28B135A2C8C3B14005F6236 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28B13592C8C3B14005F6236 /* ContentView.swift */; };
 		E28B135C2C8C3B15005F6236 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E28B135B2C8C3B15005F6236 /* Assets.xcassets */; };
@@ -17,13 +19,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		E1BA3FAD2C909F4F00ED0ADA /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
+		E1BA3FB02C90A1A600ED0ADA /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		E28B13542C8C3B14005F6236 /* Seoullo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Seoullo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E28B13572C8C3B14005F6236 /* SeoulloApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeoulloApp.swift; sourceTree = "<group>"; };
 		E28B13592C8C3B14005F6236 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		E28B135B2C8C3B15005F6236 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E28B135E2C8C3B15005F6236 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		E28B13662C8C3FD0005F6236 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
-		E28B13692C8D6F68005F6236 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -39,10 +42,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		E1BA3FAF2C90A18500ED0ADA /* Resource */ = {
+			isa = PBXGroup;
+			children = (
+				E1BA3FB02C90A1A600ED0ADA /* Colors.xcassets */,
+			);
+			path = Resource;
+			sourceTree = "<group>";
+		};
 		E28B134B2C8C3B14005F6236 = {
 			isa = PBXGroup;
 			children = (
-				E28B13692C8D6F68005F6236 /* Secrets.xcconfig */,
+				E1BA3FAD2C909F4F00ED0ADA /* Secrets.xcconfig */,
 				E28B13662C8C3FD0005F6236 /* .swiftlint.yml */,
 				E28B13562C8C3B14005F6236 /* Seoullo */,
 				E28B13552C8C3B14005F6236 /* Products */,
@@ -60,6 +71,7 @@
 		E28B13562C8C3B14005F6236 /* Seoullo */ = {
 			isa = PBXGroup;
 			children = (
+				E1BA3FAF2C90A18500ED0ADA /* Resource */,
 				E28B13572C8C3B14005F6236 /* SeoulloApp.swift */,
 				E28B13592C8C3B14005F6236 /* ContentView.swift */,
 				E28B135B2C8C3B15005F6236 /* Assets.xcassets */,
@@ -143,6 +155,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1BA3FB12C90A1A600ED0ADA /* Colors.xcassets in Resources */,
+				E1BA3FAE2C909F4F00ED0ADA /* Secrets.xcconfig in Resources */,
 				E28B13672C8C3FD0005F6236 /* .swiftlint.yml in Resources */,
 				E28B135F2C8C3B15005F6236 /* Preview Assets.xcassets in Resources */,
 				E28B135C2C8C3B15005F6236 /* Assets.xcassets in Resources */,
@@ -187,7 +201,7 @@
 /* Begin XCBuildConfiguration section */
 		E28B13602C8C3B15005F6236 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E28B13692C8D6F68005F6236 /* Secrets.xcconfig */;
+			baseConfigurationReference = E1BA3FAD2C909F4F00ED0ADA /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -251,7 +265,7 @@
 		};
 		E28B13612C8C3B15005F6236 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E28B13692C8D6F68005F6236 /* Secrets.xcconfig */;
+			baseConfigurationReference = E1BA3FAD2C909F4F00ED0ADA /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -308,7 +322,7 @@
 		};
 		E28B13632C8C3B15005F6236 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E28B13692C8D6F68005F6236 /* Secrets.xcconfig */;
+			baseConfigurationReference = E1BA3FAD2C909F4F00ED0ADA /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -338,7 +352,7 @@
 		};
 		E28B13642C8C3B15005F6236 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E28B13692C8D6F68005F6236 /* Secrets.xcconfig */;
+			baseConfigurationReference = E1BA3FAD2C909F4F00ED0ADA /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Seoullo/Seoullo/ContentView.swift
+++ b/Seoullo/Seoullo/ContentView.swift
@@ -14,6 +14,7 @@ struct ContentView: View {
                 .imageScale(.large)
                 .foregroundStyle(.tint)
             Text("Hello, world!")
+                .foregroundStyle(.point)
         }
         .padding()
     }

--- a/Seoullo/Seoullo/Resource/Colors.xcassets/Contents.json
+++ b/Seoullo/Seoullo/Resource/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Seoullo/Seoullo/Resource/Colors.xcassets/black-text.colorset/Contents.json
+++ b/Seoullo/Seoullo/Resource/Colors.xcassets/black-text.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Seoullo/Seoullo/Resource/Colors.xcassets/gray-app.colorset/Contents.json
+++ b/Seoullo/Seoullo/Resource/Colors.xcassets/gray-app.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC1",
+          "green" : "0xC1",
+          "red" : "0xC1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Seoullo/Seoullo/Resource/Colors.xcassets/green-pin.colorset/Contents.json
+++ b/Seoullo/Seoullo/Resource/Colors.xcassets/green-pin.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x01",
+          "green" : "0xA0",
+          "red" : "0x0F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Seoullo/Seoullo/Resource/Colors.xcassets/orage-pin.colorset/Contents.json
+++ b/Seoullo/Seoullo/Resource/Colors.xcassets/orage-pin.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xEA",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Seoullo/Seoullo/Resource/Colors.xcassets/orage-pin.colorset/Contents.json
+++ b/Seoullo/Seoullo/Resource/Colors.xcassets/orage-pin.colorset/Contents.json
@@ -6,7 +6,7 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0x00",
-          "green" : "0xEA",
+          "green" : "0xA6",
           "red" : "0xFF"
         }
       },

--- a/Seoullo/Seoullo/Resource/Colors.xcassets/point.colorset/Contents.json
+++ b/Seoullo/Seoullo/Resource/Colors.xcassets/point.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBF",
+          "green" : "0x96",
+          "red" : "0xB1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Seoullo/Seoullo/Resource/Colors.xcassets/red-pin.colorset/Contents.json
+++ b/Seoullo/Seoullo/Resource/Colors.xcassets/red-pin.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Seoullo/Seoullo/Resource/Colors.xcassets/subpoint.colorset/Contents.json
+++ b/Seoullo/Seoullo/Resource/Colors.xcassets/subpoint.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Seoullo/Seoullo/Resource/Colors.xcassets/yellow-pin.colorset/Contents.json
+++ b/Seoullo/Seoullo/Resource/Colors.xcassets/yellow-pin.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xA6",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Seoullo/Seoullo/Resource/Colors.xcassets/yellow-pin.colorset/Contents.json
+++ b/Seoullo/Seoullo/Resource/Colors.xcassets/yellow-pin.colorset/Contents.json
@@ -6,7 +6,7 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0x00",
-          "green" : "0xA6",
+          "green" : "0xEA",
           "red" : "0xFF"
         }
       },


### PR DESCRIPTION
## 📌 PR 설명

color asset 추가 

- 관련된 이슈: [이슈 번호] #SEO-3
- 작업한 내용 요약: [간단한 변경 내용] color asset 추가 

## 🔍 주요 변경 사항

- 메인 text 색상 : black-text
- 서브 text 색상 : gray-app
- 메인 point 색상 : point
- 서브 point 색상 : subpoint --> 아직 미정
- 핀 색상 : red-pin, orage-pin, yellow-pin, green-pin

## ✨ 사용방법 
기존 Color들처럼 Color.black-text로 사용하면 됩니다. 
